### PR TITLE
fix: add json to create scratch org output

### DIFF
--- a/scripts/deploy-script/setupsalesforceorg.js
+++ b/scripts/deploy-script/setupsalesforceorg.js
@@ -15,7 +15,7 @@ const salesforcescratchorgsetup = () => {
   );
   log("*** Creating scratch org");
   const scratchOrgResult = sh.exec(
-    `sfdx force:org:create -s -f config/project-scratch-def.json -a ${sh.env.SF_SCRATCH_ORG} -d 30 -v ${sh.env.SF_DEV_HUB}`,
+    `sfdx force:org:create -s -f config/project-scratch-def.json -a ${sh.env.SF_SCRATCH_ORG} -d 30 -v ${sh.env.SF_DEV_HUB} --json`,
     { silent: true }
   );
   // Check error creating scratch org


### PR DESCRIPTION
@albarivas Looks like not having `--json` in the create scratch org fails the command `sh.exec(sfdx force:org:create -s -f config/project-scratch-def.json -a ${sh.env.SF_SCRATCH_ORG} -d 30 -v ${sh.env.SF_DEV_HUB})` even if there is warnings like below from CLI

> [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)

Looks like warnings are also written to the std error by default and hence despite scratch org creation being successful, the deploy script fails with the warning turned to error after our latest enhancements to capture errors and throw them on the terminal.  

Surprisingly using `--json` the warnings no more go to **stderr** and fails only if scratch org creation fails