### PR TITLE
Drop chalk down to the previous esm-less version

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,7 @@
     "author": "",
     "license": "CC0 1.0 Universal",
     "dependencies": {
-        "chalk": "^5.0.0",
+        "chalk": "^4.1.2",
         "enquirer": "^2.3.6",
         "haikunator": "^2.1.2",
         "lookpath": "^1.2.2",


### PR DESCRIPTION
Hiya—with a relatively recent version of node (v17.2.0) scripts/deploy.js can no longer be run:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/gjtorikian/Documents/Contracting/DevSpotlight/sfdc/bolt/salesforce-slack-starter-kit/scripts/node_modules/chalk/source/index.js from /Users/gjtorikian/Documents/Contracting/DevSpotlight/sfdc/bolt/salesforce-slack-starter-kit/scripts/deploy.js not supported.
Instead change the require of index.js in /Users/gjtorikian/Documents/Contracting/DevSpotlight/sfdc/bolt/salesforce-slack-starter-kit/scripts/deploy.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/gjtorikian/Documents/Contracting/DevSpotlight/sfdc/bolt/salesforce-slack-starter-kit/scripts/deploy.js:4:15) {
  code: 'ERR_REQUIRE_ESM'
}
```

This is apparently by designed, as chalk [has moved to a pure ESM loading model](https://github.com/chalk/chalk/issues/528). The [steps to resolve this](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) are rather long. A quick-and-easy fix is to simply drop calk down to the previous, ESM-less version.