### PR TITLE
fix: update FOYER references to Salesforce Slack SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Salesforce Slack Starter Kit
 
-Before looking into this project, we recommend you look into [FOYER](https://developer.salesforce.com/blogs/2021/09/introducing-foyer-native-slack-integration-for-the-salesforce-platform) (currently in pilot for ISVs). Be sure to check back Salesforce [developer blog](https://developer.salesforce.com/blogs) regularly for announcements on future milestones of FOYER. If you want to become part of the pilot, contact your technical account manager.
+Before looking into this project, we recommend you look into [Salesforce Slack SDK](https://developer.salesforce.com/blogs/2021/09/introducing-foyer-native-slack-integration-for-the-salesforce-platform) (currently in pilot for ISVs). Be sure to check back Salesforce [developer blog](https://developer.salesforce.com/blogs) regularly for announcements on future milestones of Salesforce Slack SDK. If you want to become part of the pilot, contact your technical account manager.
 
 If you decide to build a custom Slack App integrated with Salesforce from scratch, this project can help you get started.
 
 ## Current Limitation
 
-Multiple salesforce org connections to a single Slack workspace are not supported. Note that FOYER will support this feature.
+Multiple salesforce org connections to a single Slack workspace are not supported. Note that Salesforce Slack SDK will support this feature.
 
 ## About the Project
 


### PR DESCRIPTION
update FOYER references to use new name 'Salesforce Slack SDK'