### PR TITLE
feat: make SF_LOGIN_URL user input independent

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -78,8 +78,6 @@ async function getUserInput() {
     const response = await userInputPrompt();
     sh.env.SF_DEV_HUB = response.devhub ?? '';
     sh.env.SF_SCRATCH_ORG = response.scratchorg ?? '';
-    sh.env.SF_LOGIN_URL =
-        response['sf-login-url'] ?? 'https://test.salesforce.com';
     sh.env.HEROKU_APP_NAME = response['heroku-app'];
     sh.env.SLACK_BOT_TOKEN = response['slack-bot-token'];
     sh.env.SLACK_SIGNING_SECRET = response['slack-signing-secret'];

--- a/scripts/deploy/setup-salesforce-non-scratch-org.js
+++ b/scripts/deploy/setup-salesforce-non-scratch-org.js
@@ -15,6 +15,22 @@ const setupNonScratchOrgUserContext = async () => {
     );
     sh.env.SF_USERNAME = userData.result.username;
     sh.env.ORGID = userData.result.id;
+    // Check if the currently authorized org is Sandbox or Production
+    const organization = JSON.parse(
+        sh.exec(
+            'sfdx force:data:soql:query -q "SELECT IsSandbox FROM Organization LIMIT 1" --json',
+            { silent: true }
+        )
+    );
+    if (organization.result.records.length > 0) {
+        if (organization.result.records[0].IsSandbox) {
+            sh.env.SF_LOGIN_URL = 'https://test.salesforce.com';
+        } else {
+            sh.env.SF_LOGIN_URL = 'https://login.salesforce.com';
+        }
+    } else {
+        sh.env.SF_LOGIN_URL = 'https://test.salesforce.com';
+    }
 };
 
 // Deploy source to non-scratch org and apply permset

--- a/scripts/deploy/setup-salesforce-scratch-org.js
+++ b/scripts/deploy/setup-salesforce-scratch-org.js
@@ -32,6 +32,7 @@ const createScratchOrg = async () => {
     );
     sh.env.SF_USERNAME = userData.result.username;
     sh.env.ORGID = userData.result.id;
+    sh.env.SF_LOGIN_URL = 'https://test.salesforce.com'; // Scratch orgs are sandboxes
 };
 
 // Push source to scratch org and apply permset


### PR DESCRIPTION
No need to now ask users whether they are connecting to sandbox or production instance. We infer this via a query to the organization object.