### PR TITLE
Bugfix: allow deploy to heroku when cli gives non-logged-out warnings

### DIFF
--- a/scripts/deploy/setup-heroku-app.js
+++ b/scripts/deploy/setup-heroku-app.js
@@ -14,7 +14,7 @@ const setupHerokuApp = async () => {
     );
     // Check user is correctly logged into Heroku
     const whoAmI = sh.exec('heroku whoami', { silent: true });
-    if (whoAmI.stderr) {
+    if (whoAmI.stderr && whoAmI.stderr.includes('not logged in')) {
         throw new Error(
             'Not logged into Heroku. Run heroku login to authenticate yourself.'
         );


### PR DESCRIPTION
Add more specific check to see if user is logged in to heroku when running the `deploy` script. This now checks for specific message from heroku cli to see if the user is logged out.
Fixes issue in #72 