### PR TITLE
Bugfix: update whoAmIResponse to use camelCase to match reponse name

### DIFF
--- a/apps/salesforce-slack-app/listeners/shortcuts/whoami.js
+++ b/apps/salesforce-slack-app/listeners/shortcuts/whoami.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-    whoamiresponse,
+    whoAmIResponse,
     authorize_sf_prompt
 } = require('../../user-interface/modals');
 
@@ -14,7 +14,7 @@ const whoamiCallback = async ({ shortcut, ack, client, context }) => {
             // Call the views.open method using one of the built-in WebClients
             await client.views.open({
                 trigger_id: shortcut.trigger_id,
-                view: whoamiresponse(conn.instanceUrl, currentuser.username)
+                view: whoAmIResponse(conn.instanceUrl, currentuser.username)
             });
         } else {
             // Get BotInfo


### PR DESCRIPTION
Update the `apps/salesforce-slack-app/listeners/shortcuts/whoami.js` to use camelCase for `whoAmIResponse` import to match that of the actual modal response.
Fixes #74 