### PR TITLE
fix: Trailhead bug TCF-026086

### DIFF
--- a/apps/salesforce-slack-app/config/config.js
+++ b/apps/salesforce-slack-app/config/config.js
@@ -26,6 +26,8 @@ const privateKeyBase64Decoded = Buffer.from(
     'base64'
 ).toString('ascii');
 
+console.log(privateKeyBase64Decoded);
+
 const salesforce = {
     clientId: process.env.SF_CLIENT_ID,
     clientSecret: process.env.SF_CLIENT_SECRET,

--- a/apps/salesforce-slack-app/config/config.js
+++ b/apps/salesforce-slack-app/config/config.js
@@ -26,8 +26,6 @@ const privateKeyBase64Decoded = Buffer.from(
     'base64'
 ).toString('ascii');
 
-console.log(privateKeyBase64Decoded);
-
 const salesforce = {
     clientId: process.env.SF_CLIENT_ID,
     clientSecret: process.env.SF_CLIENT_SECRET,

--- a/apps/salesforce-slack-app/config/config.js
+++ b/apps/salesforce-slack-app/config/config.js
@@ -21,11 +21,16 @@ requiredEnvVars.forEach((envVar) => {
 
 const defaultSalesforceApiVersion = '54.0';
 
+const privateKeyBase64Decoded = Buffer.from(
+    process.env.PRIVATE_KEY,
+    'base64'
+).toString('ascii');
+
 const salesforce = {
     clientId: process.env.SF_CLIENT_ID,
     clientSecret: process.env.SF_CLIENT_SECRET,
     herokuUrl: process.env.HEROKU_URL,
-    privateKey: process.env.PRIVATE_KEY,
+    privateKey: privateKeyBase64Decoded,
     loginUrl: process.env.SF_LOGIN_URL,
     username: process.env.SF_USERNAME,
     apiVersion: process.env.SF_API_VERSION || defaultSalesforceApiVersion

--- a/scripts/deploy/setup-heroku-app.js
+++ b/scripts/deploy/setup-heroku-app.js
@@ -53,6 +53,7 @@ const setupHerokuApp = async () => {
     );
 
     log('*** Writing .env file for local development');
+    console.log(sh.env.PRIVATE_KEY);
     // Base64 encode the PRIVATE_KEY
     const privateKeyBase64Encode = Buffer.from(sh.env.PRIVATE_KEY).toString(
         'base64'

--- a/scripts/deploy/setup-heroku-app.js
+++ b/scripts/deploy/setup-heroku-app.js
@@ -53,6 +53,10 @@ const setupHerokuApp = async () => {
     );
 
     log('*** Writing .env file for local development');
+    // Base64 encode the PRIVATE_KEY
+    const privateKeyBase64Encode = Buffer.from(sh.env.PRIVATE_KEY).toString(
+        'base64'
+    );
     // Env variables for Slack Auth
     fs.writeFileSync('.env', ''); // empty the .env file for fresh write
     fs.appendFileSync(
@@ -73,18 +77,12 @@ const setupHerokuApp = async () => {
         'SF_CLIENT_SECRET=' + sh.env.SF_CLIENT_SECRET + '\r\n'
     );
     fs.appendFileSync('.env', 'AES_KEY=' + sh.env.AES_KEY + '\r\n');
-    fs.appendFileSync(
-        '.env',
-        'PRIVATE_KEY=' +
-            '"' +
-            sh.env.PRIVATE_KEY.replace(/(\r\n|\r|\n)/g, '\\n') +
-            '"'
-    );
+    fs.appendFileSync('.env', 'PRIVATE_KEY=' + privateKeyBase64Encode);
 
     log('*** Pushing app to Heroku');
     log('*** Setting remote configuration parameters');
     sh.exec(
-        `heroku config:set PRIVATE_KEY="${sh.env.PRIVATE_KEY}" -a ${sh.env.HEROKU_APP_NAME}`,
+        `heroku config:set PRIVATE_KEY=${privateKeyBase64Encode} -a ${sh.env.HEROKU_APP_NAME}`,
         { silent: true }
     );
     // Needed by buildpack

--- a/scripts/deploy/setup-heroku-app.js
+++ b/scripts/deploy/setup-heroku-app.js
@@ -53,7 +53,6 @@ const setupHerokuApp = async () => {
     );
 
     log('*** Writing .env file for local development');
-    console.log(sh.env.PRIVATE_KEY);
     // Base64 encode the PRIVATE_KEY
     const privateKeyBase64Encode = Buffer.from(sh.env.PRIVATE_KEY).toString(
         'base64'


### PR DESCRIPTION
The command `heroku config:set PRIVATE_KEY="${sh.env.PRIVATE_KEY}" -a ${sh.env.HEROKU_APP_NAME}` fails in windows OS. 

I did a debug in the windows machine and turns out the problem is too deep in the Heroku config command, not able to consider multiline environment variable.

I have reworked this to now simply use a base64 encoding that turns multiline string into a single line string. This approach works in all the Operating system including windows OSX. 

This also address [this](https://github.com/developerforce/salesforce-slack-starter-kit/issues/29) issue